### PR TITLE
Remove pandas dependency

### DIFF
--- a/improve_i2b2_notes.py
+++ b/improve_i2b2_notes.py
@@ -1,4 +1,3 @@
-import pandas 
 import xml.etree.ElementTree as ET
 import sys
 import argparse
@@ -6,7 +5,6 @@ sys.path
 sys.path.append('/usr/local/lib/python2.7/site-packages/')
 import xmltodict
 import os
-import pandas as pd
 import re
 
 # This script removes PHI tags that are not PHI (according to HIPAA) from i2b2 annotations
@@ -118,9 +116,6 @@ def main():
 		os.makedirs(output_dir)
 	except OSError:
 		print("Output directory already exists.")
-
-	cols = ["Document", "PHI_element", "Text", "Type","Comment"]
-	output_df = pd.DataFrame(columns = cols,index=None)
 
 	new_dict = dict()
 

--- a/philter_ucsf/improve_i2b2_notes.py
+++ b/philter_ucsf/improve_i2b2_notes.py
@@ -1,4 +1,3 @@
-import pandas 
 import xml.etree.ElementTree as ET
 import sys
 import argparse
@@ -6,7 +5,6 @@ sys.path
 sys.path.append('/usr/local/lib/python2.7/site-packages/')
 import xmltodict
 import os
-import pandas as pd
 import re
 
 # This script removes PHI tags that are not PHI (according to HIPAA) from i2b2 annotations
@@ -118,9 +116,6 @@ def main():
 		os.makedirs(output_dir)
 	except OSError:
 		print("Output directory already exists.")
-
-	cols = ["Document", "PHI_element", "Text", "Type","Comment"]
-	output_df = pd.DataFrame(columns = cols,index=None)
 
 	new_dict = dict()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 chardet==3.0.4
 nltk==3.5
 numpy==1.19.0
-pandas==1.0.5
 xmltodict==0.12.0


### PR DESCRIPTION
Removes the dependency on pandas, as it is a heavy library, and wasn't actually being leveraged in the codebase.  The locations where it was imported were not actually using the dataframes.

I did notice that this also seems to have the `build` folder checked in here, which I'm guessing was accidental, but if not let me know.  I didn't update the files in there as they seemed to just be auto-generated copies.

I didn't see any contributing guidelines, so if you need anything else let me know!