### PR TITLE
Add dependencies to setup.py

### DIFF
--- a/philter_ucsf/setup.py
+++ b/philter_ucsf/setup.py
@@ -19,4 +19,11 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
+    install_requires=[
+        "chardet~=3.0",
+        "nltk~=3.5",
+        "numpy~=1.19",
+        "pandas~=1.0",
+        "xmltodict~=0.12"
+    ]
 )


### PR DESCRIPTION
Setup py isn't setting dependencies, so it doesn't install properly from PyPI.  This adds those dependencies as compat versions so that others can pip install this.