### PR TITLE
Switch file path creation from using string concatenation to using os.path.join

### DIFF
--- a/philter.py
+++ b/philter.py
@@ -2,6 +2,7 @@ import re
 import warnings
 import json
 import os
+from os.path import join
 import nltk
 import itertools
 import chardet
@@ -138,7 +139,7 @@ class Philter:
         if self.cache_to_disk:
             pos_path = self.pos_path
             filename = filename.split("/")[-1]
-            file_ = pos_path + filename
+            file_ = join(pos_path , filename)
             if filename not in self.pos_tags:
                 self.pos_tags = {}
                 if not os.path.isfile(file_):
@@ -780,7 +781,7 @@ class Philter:
             #keeps a record of all phi coordinates and text for a given file
             # data = {}
         
-            filename = root+f
+            filename = join(root,f)
 
             if filename.split(".")[-1] not in allowed_filetypes:
                 if self.verbose:
@@ -794,7 +795,7 @@ class Philter:
 
             #now we transform the text
             fbase, fext = os.path.splitext(f)
-            outpathfbase = out_path + fbase
+            outpathfbase = join(out_path , fbase)
             if self.outformat == "asterisk":
                 with open(outpathfbase+".txt", "w", encoding='utf-8', errors='surrogateescape') as f:
                     contents = self.transform_text_asterisk(txt, filename)
@@ -1079,9 +1080,9 @@ class Philter:
                 true_negatives  = [] #non-phi we correctly identify
                 true_negatives_coords = []
 
-                original_filename = note_path+f
-                philtered_filename = root+f
-                anno_filename = anno_path+''.join(f.split(".")[0])+anno_suffix
+                original_filename = join(note_path,f)
+                philtered_filename = join(root,f)
+                anno_filename = join(anno_path,''.join(f.split(".")[0])+anno_suffix)
 
                 # if len(anno_suffix) > 0:
                 #     anno_filename = anno_folder+f.split(".")[0]+anno_suffix
@@ -1319,7 +1320,7 @@ class Philter:
         for fn in summary_coords['summary_by_file']:
             # print(self.patterns)
             # get input notes filename (for filter analysis wit coordinatemap)
-            input_filename = self.finpath + os.path.basename(fn)
+            input_filename = join(self.finpath, os.path.basename(fn))
 
             current_summary =  summary_coords['summary_by_file'][fn]
 
@@ -2192,27 +2193,27 @@ class Philter:
 
         # Write FN and FP results to outfolder
         # Conext
-        with open(self.eval_outpath + "fn_tags_context.txt", "w") as fn_file:
+        with open(join(self.eval_outpath, "fn_tags_context.txt"), "w") as fn_file:
             fn_file.write("key" + "|" + "note_word" + "|" + "phi_tag" + "|" + "pos_tag" + "|" + "context" + "|" + "filename"+ "|" +"include_exclude" + "|" +"exclude_filters" + "|" +"include_filters" +"\n")
             # print(fn_tags_condensed_context)
             for key in fn_tags_condensed_context:
                 current_list = fn_tags_condensed_context[key]
                 fn_file.write(key + "|" + current_list[0] + "|" + current_list[1] + "|" + current_list[2] + "|" + current_list[3] + "|" + current_list[4]+ "|" +current_list[5]+ "|" +str(current_list[6]) + "|" +str(current_list[7]) + "\n")
         
-        with open(self.eval_outpath + "fp_tags_context.txt", "w") as fp_file:
+        with open(join(self.eval_outpath, "fp_tags_context.txt"), "w") as fp_file:
             fp_file.write("key" + "|" + "note_word" + "|" + "pos_tag" + "|" + "context" + "|" + "filename"+ "|" +"exclude_filters" + "|" +"include_filters" +"\n")
             for key in fp_tags_condensed_context:
                 current_list = fp_tags_condensed_context[key]
                 fp_file.write(key + "|" + current_list[0] + "|" + current_list[1]  + "|" +  current_list[2] + "|" + current_list[3]+ "|" + str(current_list[4]) + "|" + str(current_list[5]) +"\n")
 
         # No context
-        with open(self.eval_outpath + "fn_tags.txt", "w") as fn_file:
+        with open(join(self.eval_outpath, "fn_tags.txt"), "w") as fn_file:
             fn_file.write("key" + "|" + "note_word" + "|" + "phi_tag" + "|" + "pos_tag" + "|" + "occurrences"+"|" +"include_exclude" + "|" +"exclude_filters" + "|" +"include_filters" + "\n")
             for key in fn_tags_condensed:
                 current_list = fn_tags_condensed[key]
                 fn_file.write(key + "|" + current_list[0] + "|" + current_list[1] + "|" + current_list[2] + "|" + str(current_list[3])+"|" + current_list[4]+ "|" + str(current_list[5])+ "|" + str(current_list[6])+"\n")
         
-        with open(self.eval_outpath + "fp_tags.txt", "w") as fp_file:
+        with open(join(self.eval_outpath, "fp_tags.txt"), "w") as fp_file:
             fp_file.write("key" + "|" + "note_word" + "|" + "pos_tag" + "|" + "occurrences"+ "|" +"exclude_filters" + "|" +"include_filters" + "\n")
             for key in fp_tags_condensed:
                 current_list = fp_tags_condensed[key]
@@ -2257,25 +2258,25 @@ class Philter:
            
             for f in files:
                
-                if not os.path.exists(root+f):
-                    raise Exception("FILE DOESNT EXIST", root+f)
+                if not os.path.exists(join(root,f)):
+                    raise Exception("FILE DOESNT EXIST", join(root,f))
 
                 if len(anno_suffix) > 0:
-                    if not os.path.exists(anno_folder+f.split(".")[0]+anno_suffix):
-                        print("FILE DOESNT EXIST", anno_folder+f.split(".")[0]+anno_suffix)
+                    if not os.path.exists(join(anno_folder, f.split(".")[0]+anno_suffix)):
+                        print("FILE DOESNT EXIST", join(anno_folder, f.split(".")[0]+anno_suffix))
                         continue
                 else:
-                    if not os.path.exists(anno_folder+f):
-                        print("FILE DOESNT EXIST", anno_folder+f)
+                    if not os.path.exists(join(anno_folder, f)):
+                        print("FILE DOESNT EXIST", join(anno_folder, f))
                         continue
 
-                orig_filename = root+f
+                orig_filename = join(root,f)
                 encoding1 = self.detect_encoding(orig_filename)
                 orig = open(orig_filename,"r", encoding=encoding1['encoding']).read()
 
                 orig_words = re.split("\s+", orig)
 
-                anno_filename = anno_folder+f.split(".")[0]+anno_suffix
+                anno_filename = join(anno_folder, f.split(".")[0]+anno_suffix)
                 encoding2 = self.detect_encoding(anno_filename)
                 anno = open(anno_filename,"r", encoding=encoding2['encoding']).read()
                 anno_words = re.split("\s+", anno)


### PR DESCRIPTION
If it uses os.path.join instead of '+' to join directories to filenames it is less fussy about what the input arguments look like (whether they have a trailing slash).